### PR TITLE
Add closed spawn sprites

### DIFF
--- a/cnc/chrome.svg
+++ b/cnc/chrome.svg
@@ -2141,16 +2141,16 @@
      inkscape:label="misc">
     <g
        inkscape:label="spawn-claimed"
-       transform="translate(372,443.00002)"
+       transform="translate(338.5,214.50002)"
        id="g4988">
       <circle
-         r="8.5"
+         r="8"
          cy="549.86218"
          cx="414.5"
          id="path3998"
          style="fill:none;stroke:#3c0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <circle
-         r="9"
+         r="8.5"
          cy="549.86218"
          cx="414.5"
          style="fill:none;stroke:#800000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -2158,20 +2158,52 @@
     </g>
     <g
        inkscape:label="spawn-unclaimed"
-       transform="translate(392,423.00002)"
+       transform="matrix(1.0000001,0,0,0.99999832,358.49998,233.50093)"
        id="g4984">
       <circle
-         r="8.5"
+         r="8"
          cy="549.86218"
          cx="394.5"
          style="fill:#000000;fill-opacity:0.752941;stroke:#3c0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="path3782-8-9" />
       <circle
-         r="9"
+         r="8.5"
          cy="549.86218"
          cx="394.5"
          id="path3996"
          style="fill:none;stroke:#800000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
+       inkscape:label="spawn-disabled"
+       id="g9711"
+       transform="translate(-71,-195.99998)">
+      <circle
+         id="circle9649"
+         style="display:inline;fill:#000000;fill-opacity:0.752941;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         cx="824"
+         cy="998.36218"
+         r="8" />
+      <path
+         id="path714"
+         d="m 818.3989,991.74101 11.32543,13.12509"
+         style="display:inline;fill:none;stroke:#ffffff;stroke-width:2.2513;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+      <path
+         style="display:inline;fill:#ff0000;fill-opacity:1;stroke:#ffffff;stroke-width:2.63021;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal;enable-background:new"
+         d="m 829.47079,991.67799 -11.06813,13.45591"
+         id="path714-6" />
+      <ellipse
+         style="fill:none;stroke:#3c0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle9698"
+         cx="824"
+         cy="998.36218"
+         rx="8"
+         ry="7.9999881" />
+      <circle
+         style="fill:none;stroke:#800000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle9651"
+         cx="824"
+         cy="998.36218"
+         r="8.5" />
     </g>
     <g
        inkscape:label="faction-random"

--- a/d2k/glyphs.svg
+++ b/d2k/glyphs.svg
@@ -498,7 +498,7 @@
        id="g18893"
        style="display:inline"
        inkscape:label="spawn-selected"
-       transform="translate(0,-540.36413)">
+       transform="translate(-41.000458,-540.36413)">
       <ellipse
          cy="670.36224"
          cx="79.000519"
@@ -523,7 +523,7 @@
     </g>
     <ellipse
        cy="129.99997"
-       cx="101.99978"
+       cx="60.999779"
        id="ellipse18888"
        style="opacity:1;fill:#8c8c8c;fill-opacity:1;stroke:#202020;stroke-width:0.99999899;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        rx="8.4997797"
@@ -547,6 +547,32 @@
          id="path1498"
          d="m 936.5,223.5 h 7 l 6,-6.50007 v 22 l -6,-6.49993 h -7 z"
          style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" />
+    </g>
+    <g
+       inkscape:label="spawn-disabled"
+       id="g4241"
+       style="display:inline;enable-background:new"
+       transform="matrix(1.0000025,0,0,0.99991393,-41.0003,-565.30312)">
+      <ellipse
+         inkscape:label="spawn-disabled"
+         cy="695.36298"
+         cx="125.00056"
+         id="ellipse1634"
+         style="display:inline;fill:#8c8c8c;fill-opacity:1;stroke:#202020;stroke-width:1.00157;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         rx="8.4997797"
+         ry="8.4999676" />
+      <path
+         inkscape:label="cross"
+         inkscape:connector-curvature="0"
+         id="path714-8"
+         d="m 119.39826,688.74127 11.32715,13.12654"
+         style="display:inline;fill:none;stroke:#202020;stroke-width:2.25159;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+      <path
+         inkscape:label="cross"
+         inkscape:connector-curvature="0"
+         style="display:inline;fill:#ff0000;fill-opacity:1;stroke:#202020;stroke-width:2.63055;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal;enable-background:new"
+         d="m 130.47183,688.67824 -11.06981,13.4574"
+         id="path714-6-8" />
     </g>
   </g>
   <g

--- a/ra/glyphs.svg
+++ b/ra/glyphs.svg
@@ -388,7 +388,7 @@
      transform="translate(0,-540.3622)"
      style="display:inline">
     <g
-       inkscape:label="spawn-unclaimed"
+       inkscape:label="spawn-claimed"
        id="g18893">
       <ellipse
          cy="670.36224"
@@ -418,12 +418,12 @@
        rx="8.4997797"
        style="opacity:1;fill:#e44d4d;fill-opacity:1;stroke:#501616;stroke-width:0.99999899;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="ellipse18911"
-       cx="147.99979"
+       cx="170.99933"
        cy="670.36218" />
     <ellipse
        inkscape:label="spawn-unclaimed-green"
-       cy="670.36218"
-       cx="193.99979"
+       cy="693.36224"
+       cx="170.99979"
        id="ellipse18913"
        style="opacity:1;fill:#64cb6c;fill-opacity:1;stroke:#165016;stroke-width:0.99999899;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        rx="8.4997797"
@@ -438,7 +438,8 @@
        ry="8.4999676" />
     <g
        inkscape:label="spawn-claimed-red"
-       id="g18929">
+       id="g18929"
+       transform="translate(22.999542)">
       <ellipse
          ry="9.4998341"
          rx="9.4999504"
@@ -463,7 +464,8 @@
     </g>
     <g
        inkscape:label="spawn-claimed-green"
-       id="g18924">
+       id="g18924"
+       transform="translate(-23.000465,23.000065)">
       <ellipse
          cy="670.36224"
          cx="171.00052"
@@ -487,10 +489,34 @@
          ry="8.4999676" />
     </g>
     <g
+       inkscape:label="spawn-disabled"
+       style="stroke-width:1.00003"
+       transform="matrix(0.99993356,0,0,1,0.00773989,-25.000008)"
+       id="g4241">
+      <ellipse
+         ry="8.4999676"
+         rx="8.4997797"
+         style="display:inline;fill:#8c8c8c;fill-opacity:1;stroke:#202020;stroke-width:1.0016;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="ellipse1634"
+         cx="125.00056"
+         cy="695.36298"
+         inkscape:label="spawn-unoccupied" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;fill:none;stroke:#202020;stroke-width:2.25166;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 119.39826,688.74127 11.32715,13.12654"
+         id="path714-8" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path714-6-8"
+         d="m 130.47183,688.67824 -11.06981,13.4574"
+         style="display:inline;fill:#ff0000;fill-opacity:1;stroke:#202020;stroke-width:2.63064;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal;enable-background:new" />
+    </g>
+    <g
        inkscape:label="muted"
        id="g3187"
        style="display:inline;enable-background:new"
-       transform="translate(-867.5,469.36243)">
+       transform="translate(-714.5,341.36211)">
       <path
          inkscape:label="muted-cross"
          id="path691"

--- a/ts/glyphs.svg
+++ b/ts/glyphs.svg
@@ -388,8 +388,33 @@
      transform="translate(0,-540.3622)"
      style="display:inline">
     <g
+       inkscape:label="spawn-disabled"
+       transform="translate(-40.999992,-25.000024)"
+       style="display:inline;enable-background:new"
+       id="g4241">
+      <ellipse
+         ry="8.4999676"
+         rx="8.4997797"
+         style="display:inline;fill:#8c8c8c;fill-opacity:1;stroke:#202020;stroke-width:1.00157;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="ellipse1634"
+         cx="125.00056"
+         cy="695.36298"
+         inkscape:label="spawn-unoccupied" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;fill:none;stroke:#202020;stroke-width:2.25159;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 119.39826,688.74127 11.32715,13.12654"
+         id="path714-8" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path714-6-8"
+         d="m 130.47183,688.67824 -11.06981,13.4574"
+         style="display:inline;fill:#ff0000;fill-opacity:1;stroke:#202020;stroke-width:2.63055;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal;enable-background:new" />
+    </g>
+    <g
        inkscape:label="spawn-occupied"
-       id="g18893">
+       id="g18893"
+       transform="translate(-41.000458)">
       <ellipse
          cy="670.36224"
          cx="79.000519"
@@ -415,7 +440,7 @@
     <ellipse
        inkscape:label="spawn-unoccupied"
        cy="670.36218"
-       cx="101.99978"
+       cx="60.999779"
        id="ellipse18888"
        style="opacity:1;fill:#8c8c8c;fill-opacity:1;stroke:#202020;stroke-width:0.99999899;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        rx="8.4997797"


### PR DESCRIPTION
This is the art changes corresponding to the closed spawns feature in https://github.com/OpenRA/OpenRA/pull/18425

It would be nice if Inkscape exported in a much similar format so the diffs aren't so massive here, all I did was copy one of the spawn circles and draw two lines to make the X.